### PR TITLE
Use default values for parameter values instead of their names

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,21 @@ Only [Swagger schema 2.0 specification](https://github.com/swagger-api/swagger-s
 
 ### Build & Install
 
+install dependencies
+
 ```shell
 npm install
+```
+
+in order to get the cake command, you might need to run
+
+```shell
+npm install -g coffee-script
+```
+
+then build and run with cake
+
+```shell
 cake build
 cake install
 ```

--- a/SwaggerImporter.coffee
+++ b/SwaggerImporter.coffee
@@ -27,15 +27,15 @@ SwaggerImporter = ->
 
           # Add Queries
           if swaggerRequestParamValue.in == 'query' and swaggerRequestParamValue.type == 'string'
-            queries[swaggerRequestParamValue.name] = swaggerRequestParamValue.name
+            queries[swaggerRequestParamValue.name] = if swaggerRequestParamValue.default then swaggerRequestParamValue.default else sswaggerRequestParamValue.name
 
           # Add Headers
           if swaggerRequestParamValue.in == 'header' and swaggerRequestParamValue.type == 'string'
-            headers[swaggerRequestParamValue.name] = swaggerRequestParamValue.name
+            headers[swaggerRequestParamValue.name] = if swaggerRequestParamValue.default then swaggerRequestParamValue.default else swaggerRequestParamValue.name
 
           # Add Url Encoded
           if swaggerRequestParamValue.in == 'formData' and swaggerRequestParamValue.type == 'string'
-            formData[swaggerRequestParamValue.name] = swaggerRequestParamValue.name
+            formData[swaggerRequestParamValue.name] = if swaggerRequestParamValue.default then swaggerRequestParamValue.default else sswaggerRequestParamValue.name
 
           # Add Body
           if swaggerRequestParamValue.in == 'body' #Only string

--- a/SwaggerImporter.coffee
+++ b/SwaggerImporter.coffee
@@ -80,11 +80,20 @@ SwaggerImporter = ->
     @json_from_definition_schema = (swaggerCollection, property, indent = 0) ->
 
         if property.type == 'string'
-            s = "\"string\""
+        	if property.hasOwnProperty("default") && property.default?
+	            s = "\"" + property.default + "\""
+	        else
+	        	s = "\"string\""
         else if property.type == 'integer'
-            s = "0"
+            if property.hasOwnProperty("default") && property.default?
+                s = property.default
+            else
+            	s = "0"
         else if property.type == 'boolean'
-            s = "true"
+            if property.hasOwnProperty("default") && property.default?
+                s = property.default
+            else
+            	s = "true"
         else if typeof(property) == 'object'
             indent_str = Array(indent + 1).join('    ')
             indent_str_children = Array(indent + 2).join('    ')

--- a/SwaggerImporter.coffee
+++ b/SwaggerImporter.coffee
@@ -27,7 +27,7 @@ SwaggerImporter = ->
 
           # Add Queries
           if swaggerRequestParamValue.in == 'query' and swaggerRequestParamValue.type == 'string'
-            queries[swaggerRequestParamValue.name] = if swaggerRequestParamValue.default then swaggerRequestParamValue.default else sswaggerRequestParamValue.name
+            queries[swaggerRequestParamValue.name] = if swaggerRequestParamValue.default then swaggerRequestParamValue.default else swaggerRequestParamValue.name
 
           # Add Headers
           if swaggerRequestParamValue.in == 'header' and swaggerRequestParamValue.type == 'string'
@@ -35,7 +35,7 @@ SwaggerImporter = ->
 
           # Add Url Encoded
           if swaggerRequestParamValue.in == 'formData' and swaggerRequestParamValue.type == 'string'
-            formData[swaggerRequestParamValue.name] = if swaggerRequestParamValue.default then swaggerRequestParamValue.default else sswaggerRequestParamValue.name
+            formData[swaggerRequestParamValue.name] = if swaggerRequestParamValue.default then swaggerRequestParamValue.default else swaggerRequestParamValue.name
 
           # Add Body
           if swaggerRequestParamValue.in == 'body' #Only string


### PR DESCRIPTION
currently the importer by default sets the parameter value (for parameter types header, query and formData) to its name.

this change uses the default value as a parameter value if existing

example:

old:

```
Accept-Language: Accept-Language
```

new:

```
Accept-Language: de_DE
```
