### PR TITLE
Globally configured 'consumes' attribute will be propagated down to individual requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules/
 build/
+.nvmrc

--- a/SwaggerImporter.coffee
+++ b/SwaggerImporter.coffee
@@ -156,6 +156,13 @@ SwaggerImporter = ->
 
         for own swaggerRequestMethod, swaggerRequestValue of swaggerRequestPathValue
 
+            # Add global 'consumes' to individual pawRequest
+            if swaggerCollection.consumes
+              # Don't override the RequestValue.consumes with the global swaggerCollection.consumes, if
+              # the individual RequestValue.consumes is already set
+              if not swaggerRequestValue.consumes?.length
+                swaggerRequestValue.consumes = swaggerCollection.consumes
+
             # Create a Paw request
             pawRequest = @createPawRequest context, swaggerCollection, swaggerRequestPathName, swaggerRequestMethod, swaggerRequestValue
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Paw-SwaggerImporter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "devDependencies": {
     "coffee-script": "latest",
     "mkdirp": "~0.5.0",


### PR DESCRIPTION
If the global Swagger specification defines which content-types the API
can consume, this global specification needs to be propagated to a
single requests.

Only propagate this specification down to an individual request if the
consumes field is not explicitly specified for the individual request
